### PR TITLE
Added namespace to the class name argument of singleton() method

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,7 +17,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $configPath = __DIR__.'/../config/imageoptimizer.php';
         $this->mergeConfigFrom($configPath, 'imageoptimizer');
 
-        $this->app->singleton('ImageOptimizer', function ($app) {
+        $this->app->singleton('Approached\LaravelImageOptimizer\ImageOptimizer', function ($app) {
             $options = config('imageoptimizer.options');
 
             // $logger = $this->app->make('log')->getMonolog();


### PR DESCRIPTION
After some debugging I found out that the constructor of the class ImageOptimizer was never called. After adding the full class name I was able to pass the options to the class constructor.

Then I was able to compress jpgs by adding a -m60 option in the configuration file!