### PR TITLE
Publishes only our assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Approached\LaravelImageOptimizer\ServiceProvider::class,
 
 - Copy the package config to your local config with the publish command:
 ```
-php artisan vendor:publish
+php artisan vendor:publish --tag=imageoptimizer
 ```
 
 ## Usage

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -41,6 +41,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     {
         $this->publishes([
             __DIR__.'/../config/imageoptimizer.php' => config_path('imageoptimizer.php'),
-        ]);
+        ], 'imageoptimizer');
     }
 }


### PR DESCRIPTION
If we do ```php artisan vendor:publish```it will publish *all* vendors assets.

With ```php artisan vendor:publish --tag=imageoptimizer``` only this package assets are published.

🕴🏻